### PR TITLE
Fix pronto on CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ test:
     - bundle exec circlemator style-check --base-branch=develop
 ```
 
-(It probably makes sense in either the `pre` or `override` steps.)
+(Note: use local branch names, like `develop` instead of
+`origin/develop`; `origin` will be prepended for running pronto as
+necessary.)
+
+It probably makes sense to put `style-check` in either the `pre` or
+`override` steps.)
 
 `style-check` requires the following environment variable to be set:
 

--- a/lib/circlemator/style_checker.rb
+++ b/lib/circlemator/style_checker.rb
@@ -21,7 +21,7 @@ module Circlemator
         formatter = ::Pronto::Formatter::GithubFormatter.new
       end
 
-      ::Pronto.run(@base_branch, '.', formatter)
+      ::Pronto.run("origin/#{@base_branch}", '.', formatter)
     end
   end
 end

--- a/lib/circlemator/version.rb
+++ b/lib/circlemator/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Circlemator
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/spec/circlemator/style_checker_spec.rb
+++ b/spec/circlemator/style_checker_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Circlemator::StyleChecker do
 
       it 'runs pronto against that PR' do
         expect(Pronto::Formatter::GithubPullRequestFormatter).to receive(:new).and_return pronto_double
-        expect(Pronto).to receive(:run).with 'master', '.', pronto_double
+        expect(Pronto).to receive(:run).with 'origin/master', '.', pronto_double
 
         subject
 
@@ -47,7 +47,7 @@ RSpec.describe Circlemator::StyleChecker do
 
       it 'runs pronto against the commit' do
         expect(Pronto::Formatter::GithubFormatter).to receive(:new).and_return pronto_double
-        expect(Pronto).to receive(:run).with 'master', '.', pronto_double
+        expect(Pronto).to receive(:run).with 'origin/master', '.', pronto_double
 
         subject
       end


### PR DESCRIPTION
Apparently <branch> and origin/<branch> are different sometimes (I'm
guessing because of the source cache).

@rainforestapp/core