### PR TITLE
Handle weird JSON from Circle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in circlemator.gemspec
 gemspec
 
-gem 'rf-stylez'
+gem 'rf-stylez', github: 'rainforestapp/rf-stylez'
 gem 'rspec_junit_formatter'

--- a/lib/circlemator/build_canceler.rb
+++ b/lib/circlemator/build_canceler.rb
@@ -17,7 +17,7 @@ module Circlemator
       check_response resp
 
       builds = JSON.parse(resp.body)
-               .select   { |b| %w(running scheduled queued not_running).include? b.fetch('status') }
+               .select   { |b| %w(running scheduled queued not_running).include?(b.fetch('status')) && b['branch'] }
                .group_by { |b| b.fetch('branch') }
                .flat_map { |_, group| group.sort_by { |b| b.fetch('build_num') }[0...-1] }
                .map      { |b| b.fetch('build_num') }


### PR DESCRIPTION
Build https://circleci.com/gh/rainforestapp/Rainforest/26763 is failing, because
of https://circleci.com/gh/rainforestapp/Rainforest/26759 (a weird zombie build
of some sort). Anyways, we can just skip invalid-looking entries in the API
response.

@rainforestapp/core @ukd1