### PR TITLE
RF-2618 Bump the version of pronto

### DIFF
--- a/circlemator.gemspec
+++ b/circlemator.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'httparty', '~> 0.13.7'
-  spec.add_dependency 'pronto', '~> 0.6.0'
-  spec.add_dependency 'pronto-rubocop', '~> 0.6.0'
+  spec.add_dependency 'pronto', '~> 0.9.0'
+  spec.add_dependency 'pronto-rubocop', '~> 0.9.0'
   spec.add_dependency 'pronto-commentator', '~> 0'
 
   spec.add_development_dependency 'bundler', '>= 1.9'

--- a/circlemator.gemspec
+++ b/circlemator.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'httparty', '~> 0.13.7'
-  spec.add_dependency 'pronto', '~> 0.9.0'
+  spec.add_dependency 'pronto', '~> 0.9.5'
   spec.add_dependency 'pronto-rubocop', '~> 0.9.0'
   spec.add_dependency 'pronto-commentator', '~> 0'
 

--- a/lib/circlemator/version.rb
+++ b/lib/circlemator/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Circlemator
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end


### PR DESCRIPTION
So we can use `proto --staged` to check issues locally in pre-commit
hooks

I've no idea how to test this locally with the updated version of pronto-commentator due to the interelated versions of pronto defined in each project (https://github.com/rainforestapp/pronto-commentator/pull/1) - but they will need to be updated at the same time because of this.