### PR TITLE
RF-2618 Account for deprecation

### DIFF
--- a/lib/circlemator/style_checker.rb
+++ b/lib/circlemator/style_checker.rb
@@ -16,7 +16,7 @@ module Circlemator
     def check!
       pr_number, _ = PrFinder.new(@opts).find_pr
       if pr_number
-        ENV['PULL_REQUEST_ID'] = pr_number.to_s
+        ENV['PRONTO_PULL_REQUEST_ID'] = pr_number.to_s
         formatter = ::Pronto::Formatter::GithubPullRequestFormatter.new
       else
         formatter = ::Pronto::Formatter::GithubFormatter.new

--- a/lib/circlemator/version.rb
+++ b/lib/circlemator/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Circlemator
-  VERSION = '0.3.2'
+  VERSION = '0.3.3'
 end

--- a/spec/circlemator/style_checker_spec.rb
+++ b/spec/circlemator/style_checker_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Circlemator::StyleChecker do
 
         subject
 
-        expect(ENV['PULL_REQUEST_ID']).to eq pr_number.to_s
+        expect(ENV['PRONTO_PULL_REQUEST_ID']).to eq pr_number.to_s
       end
     end
 


### PR DESCRIPTION
Pronto used the PULL_REQUEST_ID environment variable, but this was
deprecated in favor of PRONTO_PULL_REQUEST_ID. Account for this change.