### PR TITLE
Ensure CIRCLE_BRANCH for tag builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,12 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Ensure CIRCLE_BRANCH
+          command: |
+            if [ -z $CIRCLE_BRANCH ]; then
+              echo "export CIRCLE_BRANCH=$CIRCLE_TAG" >> $BASH_ENV
+            fi
+      - run:
           name: Install env dependencies
           command: |
             sudo apt-get update


### PR DESCRIPTION
Random idea to fix the failing [0.4.0 build](https://circleci.com/gh/rainforestapp/circlemator/108?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).