### PR TITLE
Tag latest Docker image with :latest

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,13 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    docker build -t "gcr.io/$PROJECT_ID/circlemator:$COMMIT_SHA" .
+
+    if [ "$BRANCH_NAME" == "master" ]; then
+      docker tag "gcr.io/$PROJECT_ID/circlemator:$COMMIT_SHA" gcr.io/$PROJECT_ID/circlemator:latest
+    fi
+images:
+- 'gcr.io/$PROJECT_ID/circlemator'


### PR DESCRIPTION
When merging to master, release the image with the `latest` tag.

Cargo-culted from the helm-deploy repo.