### PR TITLE
Make GCP cloud-builder build the image correctly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    circlemator (0.6.0)
+    circlemator (0.7.0)
       httparty (~> 0.13.7)
       pronto (~> 0.9.5)
       pronto-brakeman (~> 0.9.1)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,9 @@
 steps:
+- name: gcr.io/cloud-builders/docker
+  entrypoint: 'bash'
+  args: ['-c', 'rm -rf .* * || true']
+- name: gcr.io/cloud-builders/git
+  args: ['clone', 'https://github.com/rainforestapp/circlemator', '-b', "$BRANCH_NAME", '.']
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
   args:


### PR DESCRIPTION
GCP cloud builder uses a git export and not a clone to build the image, this makes `rake install:local` fail because it uses `git ls-files` to build a list of files in the gem (including the circlemator executable).

Change the build process so we clone the repo instead of using the cloud builder generated export.