### PR TITLE
RF-19905 Use DockerHub user for pulling down images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,12 @@
-version: 2
+version: 2.1
 
 jobs:
   test:
     docker:
       - image: circleci/ruby:2.7
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
     steps:
       - checkout
       - run:
@@ -46,6 +49,9 @@ jobs:
   push_to_rubygems:
     docker:
       - image: circleci/ruby:2.7
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
     steps:
       - checkout
       - run:
@@ -71,6 +77,8 @@ workflows:
             tags:
               only:
                 - /.*/
+          context:
+            - DockerHub
       - push_to_rubygems:
           requires:
             - test
@@ -81,3 +89,5 @@ workflows:
             tags:
               only:
                 - /^v.*/
+          context:
+            - DockerHub


### PR DESCRIPTION
Docker are changing their TOS to rate limit unauthenticated `docker pull`
from the start of November. The rate limiting is based on IP, so builds on
Circle will be immediately impacted. Use a paid-for account and contexts to
configure a user to pull down docker images for CI/CD.
