### PR TITLE
Fix rubocop alerts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in circlemator.gemspec
 gemspec
 
-gem 'rf-stylez'
+gem 'rf-stylez', git: 'https://github.com/rainforestapp/rf-stylez.git', branch: 'upgrade_versions'
 gem 'rspec_junit_formatter'

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
-source 'https://rubygems.org'
+
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in circlemator.gemspec
 gemspec
 
-gem 'rf-stylez', git: 'https://github.com/rainforestapp/rf-stylez.git', branch: 'upgrade_versions'
-gem 'rspec_junit_formatter'
+gem "rf-stylez", git: "https://github.com/rainforestapp/rf-stylez.git", branch: "upgrade_versions"
+gem "rspec_junit_formatter"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: https://github.com/rainforestapp/rf-stylez.git
+  revision: 5cddb5b1b9f4164c4bfec412ebd2bab02b87f463
+  branch: upgrade_versions
+  specs:
+    rf-stylez (0.16.0)
+      get_env (~> 0.2.0)
+      reek (~> 6.1)
+      rubocop (= 1.15.0)
+      rubocop-rails (= 2.10.1)
+      rubocop-rspec (= 2.3.0)
+      unparser (~> 0.6)
+
 PATH
   remote: .
   specs:
@@ -12,18 +25,17 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4.1)
+    activesupport (7.0.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     brakeman (5.1.1)
     coderay (1.1.2)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
     diff-lcs (1.4.4)
@@ -71,11 +83,12 @@ GEM
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.8.10)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     imagen (0.1.8)
       parser (>= 2.5, != 2.5.1.1)
     json (2.3.0)
+    kwalify (0.7.2)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -84,7 +97,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0704)
-    minitest (5.14.4)
+    minitest (5.16.3)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nenv (0.3.0)
@@ -95,7 +108,7 @@ GEM
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.22.1)
-    parser (3.0.2.0)
+    parser (3.1.2.1)
       ast (~> 2.4.1)
     pronto (0.11.0)
       gitlab (~> 4.4, >= 4.4.0)
@@ -120,21 +133,18 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (4.0.6)
-    rack (2.2.3)
+    rack (3.0.3)
     rainbow (3.0.0)
     rake (13.0.6)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    reek (6.1.2)
+      kwalify (~> 0.7.0)
+      parser (~> 3.1.0)
+      rainbow (>= 2.0, < 4.0)
     regexp_parser (2.1.1)
     rexml (3.2.5)
-    rf-stylez (0.12.0)
-      get_env (~> 0.2.0)
-      rubocop (= 1.15.0)
-      rubocop-rails (= 2.10.1)
-      rubocop-rspec (= 2.3.0)
-      semantic_versioning (~> 0.2)
-      unparser (~> 0.6)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -174,7 +184,6 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
-    semantic_versioning (0.2.0)
     shellany (0.0.1)
     simplecov (0.17.1)
       docile (~> 1.1)
@@ -184,22 +193,21 @@ GEM
     simplecov-lcov (0.8.0)
     terminal-table (1.6.0)
     thor (1.1.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     undercover (0.3.4)
       imagen (>= 0.1.8)
       rainbow (>= 2.1, < 4.0)
       rugged (>= 0.27, < 1.1)
     unicode-display_width (2.0.0)
-    unparser (0.6.0)
+    unparser (0.6.5)
       diff-lcs (~> 1.3)
-      parser (>= 3.0.0)
+      parser (>= 3.1.0)
     vcr (6.0.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
@@ -209,7 +217,7 @@ DEPENDENCIES
   circlemator!
   guard-rspec (~> 4.7.3)
   rake (~> 13.0)
-  rf-stylez
+  rf-stylez!
   rspec (~> 3.10.0)
   rspec_junit_formatter
   rubocop

--- a/Guardfile
+++ b/Guardfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
-guard :rspec, cmd: 'bundle exec rspec' do
-  require 'guard/rspec/dsl'
+
+guard :rspec, cmd: "bundle exec rspec" do
+  require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)
 
   rspec = dsl.rspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,3 @@
 # frozen_string_literal: true
-require 'bundler/gem_tasks'
+
+require "bundler/gem_tasks"

--- a/circlemator.gemspec
+++ b/circlemator.gemspec
@@ -1,41 +1,42 @@
 # frozen_string_literal: true
-lib = File.expand_path('../lib', __FILE__)
+
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'circlemator/version'
+require "circlemator/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'circlemator'
+  spec.name          = "circlemator"
   spec.version       = Circlemator::VERSION
-  spec.authors       = ['Emanuel Evans']
-  spec.email         = ['emanuel@rainforestqa.com']
+  spec.authors       = ["Emanuel Evans"]
+  spec.email         = ["emanuel@rainforestqa.com"]
 
-  spec.summary       = 'A bucket of tricks for CircleCI and Github.'
+  spec.summary       = "A bucket of tricks for CircleCI and Github."
   spec.description   = <<-EOF.strip
     A few utilities for CircleCI to improve your CI workflow.
   EOF
-  spec.homepage      = 'https://github.com/rainforestapp/circlemator'
-  spec.license       = 'MIT'
+  spec.homepage      = "https://github.com/rainforestapp/circlemator"
+  spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = 'exe'
+  spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ['lib']
+  spec.require_paths = ["lib"]
 
-  spec.add_dependency 'httparty', '>= 0.13.7', '< 0.19.0'
-  spec.add_dependency 'pronto', '~> 0.11.0'
-  spec.add_dependency 'pronto-rubocop', '~> 0.11.0'
-  spec.add_dependency 'pronto-commentator', '~> 0'
-  spec.add_dependency 'pronto-undercover', '~> 0.1'
-  spec.add_dependency 'pronto-brakeman', '~> 0.11.0'
+  spec.add_dependency "httparty", ">= 0.13.7", "< 0.19.0"
+  spec.add_dependency "pronto", "~> 0.11.0"
+  spec.add_dependency "pronto-rubocop", "~> 0.11.0"
+  spec.add_dependency "pronto-commentator", "~> 0"
+  spec.add_dependency "pronto-undercover", "~> 0.1"
+  spec.add_dependency "pronto-brakeman", "~> 0.11.0"
 
-  spec.add_development_dependency 'bundler', '>= 1.9'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'vcr', '~> 6.0.0'
-  spec.add_development_dependency 'webmock', '~> 3.14.0'
-  spec.add_development_dependency 'rspec', '~> 3.10.0'
-  spec.add_development_dependency 'guard-rspec', '~> 4.7.3'
-  spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'simplecov-html'
-  spec.add_development_dependency 'simplecov-lcov'
+  spec.add_development_dependency "bundler", ">= 1.9"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "vcr", "~> 6.0.0"
+  spec.add_development_dependency "webmock", "~> 3.14.0"
+  spec.add_development_dependency "rspec", "~> 3.10.0"
+  spec.add_development_dependency "guard-rspec", "~> 4.7.3"
+  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "simplecov-html"
+  spec.add_development_dependency "simplecov-lcov"
 end

--- a/exe/circlemator
+++ b/exe/circlemator
@@ -1,33 +1,35 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
-require 'optparse'
-require_relative '../lib/circlemator/build_canceler'
-require_relative '../lib/circlemator/self_merger'
-require_relative '../lib/circlemator/github_repo'
-require_relative '../lib/circlemator/code_analyser'
-require_relative '../lib/circlemator/pr_commenter'
+
+require "optparse"
+require_relative "../lib/circlemator/build_canceler"
+require_relative "../lib/circlemator/self_merger"
+require_relative "../lib/circlemator/github_repo"
+require_relative "../lib/circlemator/code_analyser"
+require_relative "../lib/circlemator/pr_commenter"
 
 options = {}
 parser = OptionParser.new do |opts|
-  opts.banner = 'Usage: circlemator (self-merge|cancel-old|comment|test-coverage|test-security|style-check) [text] [options]'
+  opts.banner =
+    "Usage: circlemator (self-merge|cancel-old|comment|test-coverage|test-security|style-check) [text] [options]"
 
-  opts.on('-bBRANCH', '--base-branch=BRANCH', 'Base branch for merging') do |b|
+  opts.on("-bBRANCH", "--base-branch=BRANCH", "Base branch for merging") do |b|
     options[:base_branch] = b
   end
 
-  opts.on('-cBRANCH', '--compare-branch=BRANCH', 'Compare branch for merging') do |b|
+  opts.on("-cBRANCH", "--compare-branch=BRANCH", "Compare branch for merging") do |b|
     options[:compare_branch] = b
   end
 
-  opts.on('-gTOKEN', '--github-auth-token=TOKEN', 'Github auth token') do |t|
+  opts.on("-gTOKEN", "--github-auth-token=TOKEN", "Github auth token") do |t|
     options[:github_auth_token] = t
   end
 
-  opts.on('-tTOKEN', '--circle-api-token=TOKEN', 'CircleCI API token') do |t|
+  opts.on("-tTOKEN", "--circle-api-token=TOKEN", "CircleCI API token") do |t|
     options[:circle_api_token] = t
   end
 
-  opts.on('-h', '--help', 'Print this help message') do
+  opts.on("-h", "--help", "Print this help message") do
     puts opts
     exit
   end
@@ -51,20 +53,20 @@ def require_opt(opts, key)
   end
 end
 
-if !ENV['CIRCLECI']
-  puts 'Cirlemator should only be run from CircleCI'
+if !ENV["CIRCLECI"]
+  puts "Cirlemator should only be run from CircleCI"
   exit 1
 end
 
-options[:user] = require_env 'CIRCLE_PROJECT_USERNAME'
-options[:repo] = require_env 'CIRCLE_PROJECT_REPONAME'
-options[:github_auth_token] ||= ENV['GITHUB_ACCESS_TOKEN']
-options[:github_auth_token] ||= ENV['GITHUB_AUTH_TOKEN']
-ENV['PRONTO_GITHUB_ACCESS_TOKEN'] ||= options[:github_auth_token]
+options[:user] = require_env "CIRCLE_PROJECT_USERNAME"
+options[:repo] = require_env "CIRCLE_PROJECT_REPONAME"
+options[:github_auth_token] ||= ENV["GITHUB_ACCESS_TOKEN"]
+options[:github_auth_token] ||= ENV["GITHUB_AUTH_TOKEN"]
+ENV["PRONTO_GITHUB_ACCESS_TOKEN"] ||= options[:github_auth_token]
 
 case ARGV[0]
-when 'self-merge'
-  options[:sha] = require_env 'CIRCLE_SHA1'
+when "self-merge"
+  options[:sha] = require_env "CIRCLE_SHA1"
   require_opt options, :github_auth_token
   require_opt options, :base_branch
   require_opt options, :compare_branch
@@ -75,9 +77,9 @@ when 'self-merge'
   )
 
   Circlemator::SelfMerger.new(options).merge!
-when 'cancel-old'
-  options[:current_build] = require_env('CIRCLE_BUILD_NUM').to_i
-  options[:circle_api_token] ||= ENV['CIRCLE_API_TOKEN']
+when "cancel-old"
+  options[:current_build] = require_env("CIRCLE_BUILD_NUM").to_i
+  options[:circle_api_token] ||= ENV["CIRCLE_API_TOKEN"]
   require_opt options, :circle_api_token
 
   Circlemator::BuildCanceler.new(
@@ -86,9 +88,9 @@ when 'cancel-old'
     current_build: options[:current_build],
     circle_api_token: options[:circle_api_token]
   ).cancel_old_builds!
-when 'style-check'
-  options[:sha] = require_env 'CIRCLE_SHA1'
-  options[:compare_branch] ||= require_env 'CIRCLE_BRANCH'
+when "style-check"
+  options[:sha] = require_env "CIRCLE_SHA1"
+  options[:compare_branch] ||= require_env "CIRCLE_BRANCH"
   require_opt options, :github_auth_token
   require_opt options, :base_branch
   options[:github_repo] = Circlemator::GithubRepo.new(
@@ -98,9 +100,9 @@ when 'style-check'
   )
 
   Circlemator::CodeAnalyser.new(options).check_style
-when 'test-coverage'
-  options[:sha] = require_env 'CIRCLE_SHA1'
-  options[:compare_branch] ||= require_env 'CIRCLE_BRANCH'
+when "test-coverage"
+  options[:sha] = require_env "CIRCLE_SHA1"
+  options[:compare_branch] ||= require_env "CIRCLE_BRANCH"
   require_opt options, :github_auth_token
   require_opt options, :base_branch
   options[:github_repo] = Circlemator::GithubRepo.new(
@@ -110,9 +112,9 @@ when 'test-coverage'
   )
 
   Circlemator::CodeAnalyser.new(options).check_coverage
-when 'test-security'
-  options[:sha] = require_env 'CIRCLE_SHA1'
-  options[:compare_branch] ||= require_env 'CIRCLE_BRANCH'
+when "test-security"
+  options[:sha] = require_env "CIRCLE_SHA1"
+  options[:compare_branch] ||= require_env "CIRCLE_BRANCH"
   require_opt options, :github_auth_token
   require_opt options, :base_branch
   options[:github_repo] = Circlemator::GithubRepo.new(
@@ -122,9 +124,9 @@ when 'test-security'
   )
 
   Circlemator::CodeAnalyser.new(options).check_security
-when 'comment'
-  options[:sha] = require_env 'CIRCLE_SHA1'
-  options[:compare_branch] ||= require_env 'CIRCLE_BRANCH'
+when "comment"
+  options[:sha] = require_env "CIRCLE_SHA1"
+  options[:compare_branch] ||= require_env "CIRCLE_BRANCH"
   require_opt options, :github_auth_token
   require_opt options, :base_branch
   options[:github_repo] = Circlemator::GithubRepo.new(
@@ -134,7 +136,7 @@ when 'comment'
   )
 
   unless ARGV[1]
-    puts 'Please add some text to the comment!'
+    puts "Please add some text to the comment!"
     exit 1
   end
 

--- a/lib/circlemator.rb
+++ b/lib/circlemator.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'circlemator/version'
+
+require "circlemator/version"
 
 module Circlemator
 end

--- a/lib/circlemator/build_canceler.rb
+++ b/lib/circlemator/build_canceler.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
-require 'httparty'
-require 'json'
+
+require "httparty"
+require "json"
 
 module Circlemator
   class BuildCanceler
@@ -17,10 +18,10 @@ module Circlemator
       check_response resp
 
       builds = JSON.parse(resp.body)
-               .select   { |b| %w(running scheduled queued not_running).include?(b.fetch('status')) && b['branch'] }
-               .group_by { |b| b.fetch('branch') }
-               .flat_map { |_, group| group.sort_by { |b| b.fetch('build_num') }[0...-1] }
-               .map      { |b| b.fetch('build_num') }
+               .select   { |b| %w(running scheduled queued not_running).include?(b.fetch("status")) && b["branch"] }
+               .group_by { |b| b.fetch("branch") }
+               .flat_map { |_, group| group.sort_by { |b| b.fetch("build_num") }[0...-1] }
+               .map      { |b| b.fetch("build_num") }
 
       cancel_self = !!builds.delete(@current_build)
 
@@ -31,7 +32,7 @@ module Circlemator
       end
 
       if cancel_self
-        puts 'Daisy, Daisy, give me your answer, do...'
+        puts "Daisy, Daisy, give me your answer, do..."
         HTTParty.post "https://circleci.com/api/v1/project/#{@user}/#{@repo}/#{@current_build}/cancel",
                       circle_auth
       end
@@ -42,7 +43,7 @@ module Circlemator
     def circle_auth
       {
         query: { 'circle-token': @circle_api_token },
-        headers: { 'Accept' => 'application/json' },
+        headers: { "Accept" => "application/json" },
       }
     end
 

--- a/lib/circlemator/code_analyser.rb
+++ b/lib/circlemator/code_analyser.rb
@@ -34,7 +34,12 @@ module Circlemator
     end
 
     def formatter
-      pr_number, _ = PrFinder.new(**@opts).find_pr
+      pr_number, _ = PrFinder.new(
+        github_repo: @opts[:github_repo],
+        base_branch: @opts[:base_branch],
+        compare_branch: @opts[:compare_branch],
+        sha: @opts[:sha]
+      ).find_pr
       if pr_number
         ENV['PRONTO_PULL_REQUEST_ID'] = pr_number.to_s
         Pronto::Formatter::GithubPullRequestFormatter.new

--- a/lib/circlemator/code_analyser.rb
+++ b/lib/circlemator/code_analyser.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
-require 'httparty'
-require 'json'
-require 'pronto'
-require 'pronto/commentator'
-require 'circlemator/pr_finder'
+
+require "httparty"
+require "json"
+require "pronto"
+require "pronto/commentator"
+require "circlemator/pr_finder"
 
 module Circlemator
   class CodeAnalyser
@@ -13,24 +14,24 @@ module Circlemator
     end
 
     def check_coverage
-      require 'pronto/undercover'
+      require "pronto/undercover"
       run_pronto
     end
 
     def check_style
-      require 'pronto/rubocop'
+      require "pronto/rubocop"
       run_pronto
     end
 
     def check_security
-      require 'pronto/brakeman'
+      require "pronto/brakeman"
       run_pronto
     end
 
     private
 
     def run_pronto
-      Pronto.run("origin/#{@base_branch}", '.', formatter)
+      Pronto.run("origin/#{@base_branch}", ".", formatter)
     end
 
     def formatter
@@ -41,7 +42,7 @@ module Circlemator
         sha: @opts[:sha]
       ).find_pr
       if pr_number
-        ENV['PRONTO_PULL_REQUEST_ID'] = pr_number.to_s
+        ENV["PRONTO_PULL_REQUEST_ID"] = pr_number.to_s
         Pronto::Formatter::GithubPullRequestFormatter.new
       else
         Pronto::Formatter::GithubFormatter.new

--- a/lib/circlemator/github_repo.rb
+++ b/lib/circlemator/github_repo.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'httparty'
+
+require "httparty"
 
 module Circlemator
   class GithubRepo
@@ -17,7 +18,7 @@ module Circlemator
       end
     end
 
-    base_uri 'https://api.github.com/repos'
+    base_uri "https://api.github.com/repos"
 
     def initialize(user:, repo:, github_auth_token:)
       @user = user
@@ -43,7 +44,7 @@ module Circlemator
       case path
       when %r(\A#{self.class.base_uri}(/#{@user}/#{@repo}.*)\z)
         $1
-      when %r(\A#{self.class.base_uri})
+      when /\A#{self.class.base_uri}/
         raise WrongRepo.new(path, "#{@user}/#{@repo}")
       when %r(\A/.*)
         "/#{@user}/#{@repo}#{path}"
@@ -53,7 +54,7 @@ module Circlemator
     end
 
     def auth
-      { username: @auth_token, password: 'x-oauth-basic' }
+      { username: @auth_token, password: "x-oauth-basic" }
     end
   end
 end

--- a/lib/circlemator/pr_commenter.rb
+++ b/lib/circlemator/pr_commenter.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'circlemator/pr_finder'
+
+require "circlemator/pr_finder"
 
 module Circlemator
   class PrCommenter
@@ -19,11 +20,11 @@ module Circlemator
         compare_branch: @opts[:compare_branch],
         sha: @opts[:sha]
       ).find_pr
-      raise 'PR not found!' unless pr_url
+      raise "PR not found!" unless pr_url
 
       response = @github_repo.post "#{pr_url}/reviews", body: { commit_id: @sha,
                                                                 body: text,
-                                                                event: 'COMMENT',
+                                                                event: "COMMENT",
                                                               }.to_json
 
       if response.code != 200

--- a/lib/circlemator/pr_commenter.rb
+++ b/lib/circlemator/pr_commenter.rb
@@ -13,7 +13,12 @@ module Circlemator
     end
 
     def comment(text)
-      _, pr_url = PrFinder.new(**@opts).find_pr
+      _, pr_url = PrFinder.new(
+        github_repo: @opts[:github_repo],
+        base_branch: @opts[:base_branch],
+        compare_branch: @opts[:compare_branch],
+        sha: @opts[:sha]
+      ).find_pr
       raise 'PR not found!' unless pr_url
 
       response = @github_repo.post "#{pr_url}/reviews", body: { commit_id: @sha,

--- a/lib/circlemator/pr_finder.rb
+++ b/lib/circlemator/pr_finder.rb
@@ -9,7 +9,7 @@ module Circlemator
       end
     end
 
-    def initialize(github_repo:, base_branch:, compare_branch:, sha:, **_opts)
+    def initialize(github_repo:, base_branch:, compare_branch:, sha:)
       @github_repo = github_repo
       @base_branch = base_branch
       @compare_branch = compare_branch

--- a/lib/circlemator/pr_finder.rb
+++ b/lib/circlemator/pr_finder.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'circlemator/github_repo'
+
+require "circlemator/github_repo"
 
 module Circlemator
   class PrFinder
@@ -17,21 +18,21 @@ module Circlemator
     end
 
     def find_pr
-      response = @github_repo.get '/pulls', query: { base: @base_branch }
+      response = @github_repo.get "/pulls", query: { base: @base_branch }
       if response.code != 200
         raise BadResponseError, response
       end
 
       prs = JSON.parse(response.body)
       target_pr = prs.find do |pr|
-        pr.fetch('head').fetch('ref') == @compare_branch &&
-          pr.fetch('head').fetch('sha') == @sha &&
-          pr.fetch('base').fetch('ref') == @base_branch
+        pr.fetch("head").fetch("ref") == @compare_branch &&
+          pr.fetch("head").fetch("sha") == @sha &&
+          pr.fetch("base").fetch("ref") == @base_branch
       end
 
       return if target_pr.nil?
 
-      [target_pr.fetch('number'), target_pr.fetch('url')]
+      [target_pr.fetch("number"), target_pr.fetch("url")]
     end
   end
 end

--- a/lib/circlemator/self_merger.rb
+++ b/lib/circlemator/self_merger.rb
@@ -15,7 +15,12 @@ module Circlemator
     end
 
     def merge!
-      pr_number, pr_url = PrFinder.new(**@opts).find_pr
+      pr_number, pr_url = PrFinder.new(
+        github_repo: @opts[:github_repo],
+        base_branch: @opts[:base_branch],
+        compare_branch: @opts[:compare_branch],
+        sha: @opts[:sha]
+      ).find_pr
       return if pr_number.nil? || pr_url.nil?
 
       response = @github_repo.put "#{pr_url}/merge",

--- a/lib/circlemator/self_merger.rb
+++ b/lib/circlemator/self_merger.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
-require 'httparty'
-require 'json'
+
+require "httparty"
+require "json"
 
 module Circlemator
   class SelfMerger
-    MESSAGE = 'Auto-merge by Circlemator!'
+    MESSAGE = "Auto-merge by Circlemator!"
     def initialize(opts)
       github_repo = opts.fetch(:github_repo)
       raise "#{github_repo} is invalid" unless github_repo.is_a? GithubRepo

--- a/lib/circlemator/version.rb
+++ b/lib/circlemator/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Circlemator
-  VERSION = '0.7.0'
+  VERSION = "0.7.0"
 end

--- a/spec/circlemator/code_analyser_spec.rb
+++ b/spec/circlemator/code_analyser_spec.rb
@@ -1,53 +1,54 @@
 # frozen_string_literal: true
-require 'circlemator/code_analyser'
-require 'circlemator/pr_finder'
-require 'circlemator/github_repo'
-require 'pronto'
+
+require "circlemator/code_analyser"
+require "circlemator/pr_finder"
+require "circlemator/github_repo"
+require "pronto"
 
 RSpec.describe Circlemator::CodeAnalyser do
-  describe 'check!' do
+  describe "check!" do
     let(:github_repo) do
-      Circlemator::GithubRepo.new user: 'rainforestapp',
-                                  repo: 'circlemator',
-                                  github_auth_token: 'abc123'
+      Circlemator::GithubRepo.new user: "rainforestapp",
+                                  repo: "circlemator",
+                                  github_auth_token: "abc123"
     end
     let(:checker) do
       Circlemator::CodeAnalyser.new github_repo: github_repo,
-                                    sha: 'abc123',
-                                    base_branch: 'master',
-                                    compare_branch: 'topic'
+                                    sha: "abc123",
+                                    base_branch: "master",
+                                    compare_branch: "topic"
     end
     let(:pronto_double) { double }
 
     subject { checker.check_style }
 
-    context 'with an open PR' do
+    context "with an open PR" do
       let(:pr_number) { 12345 }
 
       before do
         allow_any_instance_of(Circlemator::PrFinder)
-          .to receive(:find_pr).and_return [pr_number, '']
+          .to receive(:find_pr).and_return [pr_number, ""]
       end
 
-      it 'runs pronto against that PR' do
+      it "runs pronto against that PR" do
         expect(Pronto::Formatter::GithubPullRequestFormatter).to receive(:new).and_return pronto_double
-        expect(Pronto).to receive(:run).with 'origin/master', '.', pronto_double
+        expect(Pronto).to receive(:run).with "origin/master", ".", pronto_double
 
         subject
 
-        expect(ENV['PRONTO_PULL_REQUEST_ID']).to eq pr_number.to_s
+        expect(ENV["PRONTO_PULL_REQUEST_ID"]).to eq pr_number.to_s
       end
     end
 
-    context 'without an open PR' do
+    context "without an open PR" do
       before do
         allow_any_instance_of(Circlemator::PrFinder)
           .to receive(:find_pr).and_return nil
       end
 
-      it 'runs pronto against the commit' do
+      it "runs pronto against the commit" do
         expect(Pronto::Formatter::GithubFormatter).to receive(:new).and_return pronto_double
-        expect(Pronto).to receive(:run).with 'origin/master', '.', pronto_double
+        expect(Pronto).to receive(:run).with "origin/master", ".", pronto_double
 
         subject
       end

--- a/spec/circlemator/github_repo_spec.rb
+++ b/spec/circlemator/github_repo_spec.rb
@@ -1,26 +1,27 @@
 # frozen_string_literal: true
-require 'circlemator/github_repo'
+
+require "circlemator/github_repo"
 
 RSpec.describe Circlemator::GithubRepo do
   let(:github_repo) { described_class.new(user: user, repo: repo, github_auth_token: auth_token) }
-  let(:auth_token) { 'abc123' }
-  let(:user) { 'rainforestapp' }
-  let(:repo) { 'circlemator' }
+  let(:auth_token) { "abc123" }
+  let(:user) { "rainforestapp" }
+  let(:repo) { "circlemator" }
 
-  describe '#get' do
-    context 'with a path' do
-      it 'updates the path and adds the authorization' do
+  describe "#get" do
+    context "with a path" do
+      it "updates the path and adds the authorization" do
         expect(described_class)
           .to receive(:get).with("/#{user}/#{repo}/pulls",
                                  query: { foo: :bar },
-                                 basic_auth: { username: auth_token, password: 'x-oauth-basic' })
+                                 basic_auth: { username: auth_token, password: "x-oauth-basic" })
 
-        github_repo.get('/pulls', query: { foo: :bar })
+        github_repo.get("/pulls", query: { foo: :bar })
       end
     end
 
-    context 'with a full URL' do
-      it 'changes the URL to a path' do
+    context "with a full URL" do
+      it "changes the URL to a path" do
         expect(described_class)
           .to receive(:get).with("/#{user}/#{repo}/pulls", any_args)
 
@@ -28,40 +29,40 @@ RSpec.describe Circlemator::GithubRepo do
       end
     end
 
-    context 'with an invalid path' do
-      it 'raises an error' do
-        expect { github_repo.get('foobar') }.to raise_error Circlemator::GithubRepo::InvalidPath
+    context "with an invalid path" do
+      it "raises an error" do
+        expect { github_repo.get("foobar") }.to raise_error Circlemator::GithubRepo::InvalidPath
       end
     end
 
-    context 'with a URL for the wrong repo' do
-      it 'raises an error' do
+    context "with a URL for the wrong repo" do
+      it "raises an error" do
         expect do
-          github_repo.get('https://api.github.com/repos/rails/rails/pulls')
+          github_repo.get("https://api.github.com/repos/rails/rails/pulls")
         end.to raise_error Circlemator::GithubRepo::WrongRepo
       end
     end
   end
 
-  describe '#put' do
-    it 'updates the path and adds the authorization' do
+  describe "#put" do
+    it "updates the path and adds the authorization" do
       expect(described_class)
         .to receive(:put).with("/#{user}/#{repo}/pulls/123/merge",
                                body: { foo: :bar },
-                               basic_auth: { username: auth_token, password: 'x-oauth-basic' })
+                               basic_auth: { username: auth_token, password: "x-oauth-basic" })
 
-      github_repo.put('/pulls/123/merge', body: { foo: :bar })
+      github_repo.put("/pulls/123/merge", body: { foo: :bar })
     end
   end
 
-  describe '#post' do
-    it 'updates the path and adds the authorization' do
+  describe "#post" do
+    it "updates the path and adds the authorization" do
       expect(described_class)
         .to receive(:post).with("/#{user}/#{repo}/pulls/123/comments",
                                 body: { foo: :bar },
-                                basic_auth: { username: auth_token, password: 'x-oauth-basic' })
+                                basic_auth: { username: auth_token, password: "x-oauth-basic" })
 
-      github_repo.post('/pulls/123/comments', body: { foo: :bar })
+      github_repo.post("/pulls/123/comments", body: { foo: :bar })
     end
   end
 end

--- a/spec/circlemator/pr_commenter_spec.rb
+++ b/spec/circlemator/pr_commenter_spec.rb
@@ -1,37 +1,38 @@
 # frozen_string_literal: true
-require 'circlemator/pr_finder'
-require 'circlemator/pr_commenter'
-require 'circlemator/github_repo'
+
+require "circlemator/pr_finder"
+require "circlemator/pr_commenter"
+require "circlemator/github_repo"
 
 RSpec.describe Circlemator::PrCommenter do
-  describe 'comment' do
+  describe "comment" do
     let(:github_repo) do
-      Circlemator::GithubRepo.new user: 'rainforestapp',
-                                  repo: 'circlemator',
-                                  github_auth_token: 'abc123'
+      Circlemator::GithubRepo.new user: "rainforestapp",
+                                  repo: "circlemator",
+                                  github_auth_token: "abc123"
     end
     let(:commenter) do
       Circlemator::PrCommenter.new github_repo: github_repo,
-                                   sha: 'abc123',
-                                   base_branch: 'master',
-                                   compare_branch: 'topic'
+                                   sha: "abc123",
+                                   base_branch: "master",
+                                   compare_branch: "topic"
     end
 
-    subject { commenter.comment 'FOOBAR' }
+    subject { commenter.comment "FOOBAR" }
 
-    context 'with an open PR' do
-      let(:pr_url) { 'https://api.github.com/repos/rainforestapp/circlemator/pulls/1' }
+    context "with an open PR" do
+      let(:pr_url) { "https://api.github.com/repos/rainforestapp/circlemator/pulls/1" }
 
       before do
         allow_any_instance_of(Circlemator::PrFinder)
           .to receive(:find_pr).and_return [1, pr_url]
       end
 
-      it 'comments on the PR' do
+      it "comments on the PR" do
         expect(github_repo)
-          .to receive(:post).with("#{pr_url}/reviews", body: { commit_id: 'abc123',
-                                                               body: 'FOOBAR',
-                                                               event: 'COMMENT',
+          .to receive(:post).with("#{pr_url}/reviews", body: { commit_id: "abc123",
+                                                               body: "FOOBAR",
+                                                               event: "COMMENT",
                                                              }.to_json)
                 .and_return double(code: 200)
 

--- a/spec/circlemator/pr_finder_spec.rb
+++ b/spec/circlemator/pr_finder_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
-require 'circlemator/pr_finder'
-require 'circlemator/github_repo'
-require 'json'
+
+require "circlemator/pr_finder"
+require "circlemator/github_repo"
+require "json"
 
 RSpec.describe Circlemator::PrFinder do
-  describe '#find_pr' do
+  describe "#find_pr" do
     let(:github_repo) do
-      Circlemator::GithubRepo.new(user: 'octocat', repo: 'Hello-World', github_auth_token: 'abc123')
+      Circlemator::GithubRepo.new(user: "octocat", repo: "Hello-World", github_auth_token: "abc123")
     end
     let(:finder) do
       described_class.new github_repo: github_repo,
@@ -14,27 +15,27 @@ RSpec.describe Circlemator::PrFinder do
                           compare_branch: compare_branch,
                           sha: sha
     end
-    let(:sha) { '1234567' }
-    let(:base_branch) { 'master' }
-    let(:compare_branch) { 'new-topic' }
+    let(:sha) { "1234567" }
+    let(:base_branch) { "master" }
+    let(:compare_branch) { "new-topic" }
     let(:pr_number) { 1347 }
-    let(:pr_url) { 'https://api.github.com/repos/octocat/Hello-World/pulls/1347' }
+    let(:pr_url) { "https://api.github.com/repos/octocat/Hello-World/pulls/1347" }
     let(:response) do
       [
         {
-          'id' => 1,
-          'url' => pr_url,
-          'number' => pr_number,
-          'state' => 'open',
-          'title' => 'new-feature',
-          'body' => 'Please pull these awesome changes',
-          'head' => {
-            'ref' => 'new-topic',
-            'sha' => '1234567',
+          "id" => 1,
+          "url" => pr_url,
+          "number" => pr_number,
+          "state" => "open",
+          "title" => "new-feature",
+          "body" => "Please pull these awesome changes",
+          "head" => {
+            "ref" => "new-topic",
+            "sha" => "1234567",
           },
-          'base' => {
-            'ref' => 'master',
-            'sha' => '6dcb09b5b57875f334f61aebed695e2e4193db5e',
+          "base" => {
+            "ref" => "master",
+            "sha" => "6dcb09b5b57875f334f61aebed695e2e4193db5e",
           },
         },
       ].to_json
@@ -46,36 +47,36 @@ RSpec.describe Circlemator::PrFinder do
       allow(github_repo).to receive(:get).and_return double(code: 200, body: response)
     end
 
-    context 'with a successful response' do
-      it 'returns the PR number and URL' do
+    context "with a successful response" do
+      it "returns the PR number and URL" do
         expect(subject).to eq [pr_number, pr_url]
       end
     end
 
-    context 'with an unsuccessful response' do
+    context "with an unsuccessful response" do
       before do
-        allow(github_repo).to receive(:get).and_return double(code: 500, body: 'BAD')
+        allow(github_repo).to receive(:get).and_return double(code: 500, body: "BAD")
       end
 
-      it 'raises an error' do
+      it "raises an error" do
         expect { subject }.to raise_error Circlemator::PrFinder::BadResponseError
       end
     end
 
-    context 'with a sha mismatch' do
-      let(:sha) { 'abc123' }
+    context "with a sha mismatch" do
+      let(:sha) { "abc123" }
 
       it { is_expected.to be_nil }
     end
 
-    context 'with a base branch mismatch' do
-      let(:base_branch) { 'develop' }
+    context "with a base branch mismatch" do
+      let(:base_branch) { "develop" }
 
       it { is_expected.to be_nil }
     end
 
-    context 'with a compare branch mismatch' do
-      let(:compare_branch) { 'another-topic' }
+    context "with a compare branch mismatch" do
+      let(:compare_branch) { "another-topic" }
 
       it { is_expected.to be_nil }
     end

--- a/spec/circlemator/self_merger_spec.rb
+++ b/spec/circlemator/self_merger_spec.rb
@@ -1,22 +1,23 @@
 # frozen_string_literal: true
-require 'circlemator/self_merger'
-require 'circlemator/github_repo'
-require 'circlemator/pr_finder'
+
+require "circlemator/self_merger"
+require "circlemator/github_repo"
+require "circlemator/pr_finder"
 
 RSpec.describe Circlemator::SelfMerger do
-  describe '#merge!' do
+  describe "#merge!" do
     let(:github_repo) do
-      Circlemator::GithubRepo.new user: 'rainforestapp',
-                                  repo: 'circlemator',
-                                  github_auth_token: 'abc123'
+      Circlemator::GithubRepo.new user: "rainforestapp",
+                                  repo: "circlemator",
+                                  github_auth_token: "abc123"
     end
     let(:merger) do
       described_class.new github_repo: github_repo,
-                          sha: '1234567',
-                          base_branch: 'master',
-                          compare_branch: 'topic'
+                          sha: "1234567",
+                          base_branch: "master",
+                          compare_branch: "topic"
     end
-    let(:pr_url) { 'https://api.github.com/rainforestapp/circlemator/pulls/12345' }
+    let(:pr_url) { "https://api.github.com/rainforestapp/circlemator/pulls/12345" }
 
     before do
       allow_any_instance_of(Circlemator::PrFinder)
@@ -24,10 +25,10 @@ RSpec.describe Circlemator::SelfMerger do
              .and_return [12345, pr_url]
     end
 
-    it 'merges the pull request' do
+    it "merges the pull request" do
       expect(github_repo)
         .to receive(:put).with("#{pr_url}/merge",
-                               body: { commit_message: described_class::MESSAGE, sha: '1234567' }.to_json)
+                               body: { commit_message: described_class::MESSAGE, sha: "1234567" }.to_json)
              .and_return double(code: 200)
 
       merger.merge!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
-require 'vcr'
 
-require 'simplecov'
-require 'simplecov-lcov'
+require "vcr"
+
+require "simplecov"
+require "simplecov-lcov"
 SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
   [SimpleCov::Formatter::LcovFormatter, SimpleCov::Formatter::HTMLFormatter]
@@ -25,7 +26,7 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.warnings = true
   if config.files_to_run.one?
-    config.default_formatter = 'doc'
+    config.default_formatter = "doc"
   end
   config.profile_examples = 10
   config.order = :random
@@ -33,6 +34,6 @@ RSpec.configure do |config|
 end
 
 VCR.configure do |config|
-  config.cassette_library_dir = 'fixtures/vcr_cassettes'
+  config.cassette_library_dir = "fixtures/vcr_cassettes"
   config.hook_into :webmock
 end


### PR DESCRIPTION
There are still some alerts remaining such as:
* Style/Documentation: Missing top-level class documentation comment.  --> may need help to document each class
* Lint/NoJSON: Use MultiJson instead of JSON. --> gem not included.
* Lint/NoENV: Use GetEnv instead of ENV. --> gem not included.
* Lint/NoHTTParty: Prefer TimedRequest instead of raw HTTParty calls. --> gem not included.
* An error occurred while Layout/BlockAlignment cop was inspecting /Users/sebastian/Desktop/Projects/Rainforest/circlemator/Guardfile:3:0.  --> not sure why its happening

