### PR TITLE
Reference rf-stylez from default gem source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in circlemator.gemspec
 gemspec
 
-gem 'rf-stylez', git: 'https://github.com/rainforestapp/rf-stylez.git', branch: 'upgrade_versions'
+gem 'rf-stylez'
 gem 'rspec_junit_formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: https://github.com/rainforestapp/rf-stylez.git
-  revision: 5cddb5b1b9f4164c4bfec412ebd2bab02b87f463
-  branch: upgrade_versions
-  specs:
-    rf-stylez (0.16.0)
-      get_env (~> 0.2.0)
-      reek (~> 6.1)
-      rubocop (= 1.15.0)
-      rubocop-rails (= 2.10.1)
-      rubocop-rspec (= 2.3.0)
-      unparser (~> 0.6)
-
 PATH
   remote: .
   specs:
@@ -88,7 +75,6 @@ GEM
     imagen (0.1.8)
       parser (>= 2.5, != 2.5.1.1)
     json (2.3.0)
-    kwalify (0.7.2)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -139,12 +125,15 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    reek (6.1.2)
-      kwalify (~> 0.7.0)
-      parser (~> 3.1.0)
-      rainbow (>= 2.0, < 4.0)
     regexp_parser (2.1.1)
     rexml (3.2.5)
+    rf-stylez (0.12.0)
+      get_env (~> 0.2.0)
+      rubocop (= 1.15.0)
+      rubocop-rails (= 2.10.1)
+      rubocop-rspec (= 2.3.0)
+      semantic_versioning (~> 0.2)
+      unparser (~> 0.6)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -184,6 +173,7 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
+    semantic_versioning (0.2.0)
     shellany (0.0.1)
     simplecov (0.17.1)
       docile (~> 1.1)
@@ -217,7 +207,7 @@ DEPENDENCIES
   circlemator!
   guard-rspec (~> 4.7.3)
   rake (~> 13.0)
-  rf-stylez!
+  rf-stylez
   rspec (~> 3.10.0)
   rspec_junit_formatter
   rubocop


### PR DESCRIPTION
Undoing the change that was done on this previous https://github.com/rainforestapp/circlemator/pull/159 which required referencing `rf-stylez` from a branch to get the CI green.

It is possible that first merging https://github.com/rainforestapp/rf-stylez/pull/148 and then this PR can get both CIs green again, but I'm not 100% sure.

